### PR TITLE
Remove content_order from Page

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -127,10 +127,9 @@ module Admin
 
     def permitted_page_attributes
       [
-        :template, :user_id, :status, :content_order,
-        :feed_enabled, :published_at, :redirect_to, :comments_allowed,
-        :image_link, :news_page, :unique_name, :pinned,
-        :parent_page_id, :serialized_tags, :meta_image
+        :template, :user_id, :status, :feed_enabled, :published_at,
+        :redirect_to, :comments_allowed, :image_link, :news_page,
+        :unique_name, :pinned, :parent_page_id, :serialized_tags, :meta_image
       ]
     end
 

--- a/app/controllers/pages_core/frontend/pages_controller.rb
+++ b/app/controllers/pages_core/frontend/pages_controller.rb
@@ -211,10 +211,9 @@ module PagesCore
 
       def permitted_page_attributes
         [
-          :template, :user_id, :status, :content_order,
-          :feed_enabled, :published_at, :redirect_to, :comments_allowed,
-          :image_link, :news_page, :unique_name, :pinned,
-          :parent_page_id
+          :template, :user_id, :status, :feed_enabled, :published_at,
+          :redirect_to, :comments_allowed, :image_link, :news_page,
+          :unique_name, :pinned, :parent_page_id
         ]
       end
 

--- a/app/views/admin/pages/_edit_options.html.erb
+++ b/app/views/admin/pages/_edit_options.html.erb
@@ -58,7 +58,6 @@
 
   <div class="field">
     <label>Subpages</label>
-    Sort <%= f.select(:content_order, [ ['manually','position'], ['with the newest first','published_at DESC'] ] ) %><br />
     <%= f.check_box(:feed_enabled) %> RSS feed enabled<br />
     <%= f.check_box(:news_page) %> Show in News<br />
   </div>

--- a/db/migrate/20151204151000_remove_page_content_order.rb
+++ b/db/migrate/20151204151000_remove_page_content_order.rb
@@ -1,0 +1,5 @@
+class RemovePageContentOrder < ActiveRecord::Migration
+  def change
+    remove_column :pages, :content_order, :string
+  end
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -11,75 +11,72 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151021103400) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+ActiveRecord::Schema.define(version: 20151204151000) do
 
   create_table "categories", force: :cascade do |t|
-    t.string   "name"
-    t.string   "slug"
-    t.integer  "position"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "name",       limit: 255
+    t.string   "slug",       limit: 255
+    t.integer  "position",   limit: 4
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   add_index "categories", ["slug"], name: "index_categories_on_slug", using: :btree
 
   create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0
-    t.integer  "attempts",   default: 0
-    t.text     "handler"
-    t.text     "last_error"
+    t.integer  "priority",   limit: 4,     default: 0
+    t.integer  "attempts",   limit: 4,     default: 0
+    t.text     "handler",    limit: 65535
+    t.text     "last_error", limit: 65535
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.string   "queue"
+    t.string   "locked_by",  limit: 255
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+    t.string   "queue",      limit: 255
   end
 
   create_table "images", force: :cascade do |t|
-    t.string   "filename",       null: false
-    t.string   "content_type",   null: false
+    t.string   "filename",       limit: 255, null: false
+    t.string   "content_type",   limit: 255, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "content_hash",   null: false
-    t.integer  "content_length", null: false
-    t.string   "colorspace",     null: false
-    t.integer  "real_width",     null: false
-    t.integer  "real_height",    null: false
-    t.integer  "crop_width"
-    t.integer  "crop_height"
-    t.integer  "crop_start_x"
-    t.integer  "crop_start_y"
-    t.integer  "crop_gravity_x"
-    t.integer  "crop_gravity_y"
+    t.string   "content_hash",   limit: 255, null: false
+    t.integer  "content_length", limit: 4,   null: false
+    t.string   "colorspace",     limit: 255, null: false
+    t.integer  "real_width",     limit: 4,   null: false
+    t.integer  "real_height",    limit: 4,   null: false
+    t.integer  "crop_width",     limit: 4
+    t.integer  "crop_height",    limit: 4
+    t.integer  "crop_start_x",   limit: 4
+    t.integer  "crop_start_y",   limit: 4
+    t.integer  "crop_gravity_x", limit: 4
+    t.integer  "crop_gravity_y", limit: 4
   end
 
   create_table "invite_roles", force: :cascade do |t|
-    t.integer  "invite_id"
-    t.string   "name"
+    t.integer  "invite_id",  limit: 4
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "invites", force: :cascade do |t|
-    t.integer  "user_id"
-    t.string   "email"
-    t.string   "token"
+    t.integer  "user_id",    limit: 4
+    t.string   "email",      limit: 255
+    t.string   "token",      limit: 255
     t.datetime "sent_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "localizations", force: :cascade do |t|
-    t.integer  "localizable_id"
-    t.string   "localizable_type"
-    t.string   "name"
-    t.string   "locale"
-    t.text     "value"
+    t.integer  "localizable_id",   limit: 4
+    t.string   "localizable_type", limit: 255
+    t.string   "name",             limit: 255
+    t.string   "locale",           limit: 255
+    t.text     "value",            limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -88,71 +85,70 @@ ActiveRecord::Schema.define(version: 20151021103400) do
   add_index "localizations", ["localizable_id", "localizable_type"], name: "index_localizations_on_localizable_id_and_localizable_type", using: :btree
 
   create_table "page_comments", force: :cascade do |t|
-    t.integer  "page_id"
-    t.string   "remote_ip"
-    t.string   "name"
-    t.string   "email"
-    t.string   "url"
-    t.text     "body"
+    t.integer  "page_id",    limit: 4
+    t.string   "remote_ip",  limit: 255
+    t.string   "name",       limit: 255
+    t.string   "email",      limit: 255
+    t.string   "url",        limit: 255
+    t.text     "body",       limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "page_files", force: :cascade do |t|
-    t.integer  "page_id"
-    t.integer  "position"
-    t.string   "name"
-    t.string   "filename",       null: false
-    t.string   "content_type",   null: false
-    t.integer  "content_length", null: false
+    t.integer  "page_id",        limit: 4
+    t.integer  "position",       limit: 4
+    t.string   "name",           limit: 255
+    t.string   "filename",       limit: 255, null: false
+    t.string   "content_type",   limit: 255, null: false
+    t.integer  "content_length", limit: 4,   null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "content_hash",   null: false
+    t.string   "content_hash",   limit: 255, null: false
   end
 
   create_table "page_images", force: :cascade do |t|
-    t.integer "page_id"
-    t.integer "image_id"
-    t.integer "position"
-    t.boolean "primary",  default: false, null: false
+    t.integer "page_id",  limit: 4
+    t.integer "image_id", limit: 4
+    t.integer "position", limit: 4
+    t.boolean "primary",            default: false, null: false
   end
 
   add_index "page_images", ["page_id", "primary"], name: "index_page_images_on_page_id_and_primary", using: :btree
   add_index "page_images", ["page_id"], name: "index_page_images_on_page_id", using: :btree
 
   create_table "page_paths", force: :cascade do |t|
-    t.integer  "page_id"
-    t.string   "locale"
-    t.string   "path"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "page_id",    limit: 4
+    t.string   "locale",     limit: 255
+    t.string   "path",       limit: 255
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   add_index "page_paths", ["locale", "path"], name: "index_page_paths_on_locale_and_path", unique: true, using: :btree
 
   create_table "pages", force: :cascade do |t|
-    t.integer  "parent_page_id"
-    t.integer  "position"
-    t.string   "byline"
-    t.string   "template"
+    t.integer  "parent_page_id",   limit: 4
+    t.integer  "position",         limit: 4
+    t.string   "byline",           limit: 255
+    t.string   "template",         limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id"
-    t.integer  "status",           default: 0,     null: false
-    t.string   "content_order"
-    t.boolean  "feed_enabled",     default: false, null: false
+    t.integer  "user_id",          limit: 4
+    t.integer  "status",           limit: 4,   default: 0,     null: false
+    t.boolean  "feed_enabled",                 default: false, null: false
     t.datetime "published_at"
-    t.string   "redirect_to"
-    t.integer  "image_id"
-    t.boolean  "comments_allowed", default: true,  null: false
-    t.string   "image_link"
-    t.boolean  "news_page",        default: false, null: false
-    t.boolean  "autopublish",      default: false, null: false
-    t.string   "unique_name"
-    t.integer  "comments_count",   default: 0,     null: false
+    t.string   "redirect_to",      limit: 255
+    t.integer  "image_id",         limit: 4
+    t.boolean  "comments_allowed",             default: true,  null: false
+    t.string   "image_link",       limit: 255
+    t.boolean  "news_page",                    default: false, null: false
+    t.boolean  "autopublish",                  default: false, null: false
+    t.string   "unique_name",      limit: 255
+    t.integer  "comments_count",   limit: 4,   default: 0,     null: false
     t.datetime "last_comment_at"
-    t.boolean  "pinned",           default: false, null: false
-    t.integer  "meta_image_id"
+    t.boolean  "pinned",                       default: false, null: false
+    t.integer  "meta_image_id",    limit: 4
   end
 
   add_index "pages", ["parent_page_id"], name: "index_pages_on_parent_page_id", using: :btree
@@ -162,24 +158,24 @@ ActiveRecord::Schema.define(version: 20151021103400) do
   add_index "pages", ["user_id"], name: "index_pages_on_user_id", using: :btree
 
   create_table "pages_categories", id: false, force: :cascade do |t|
-    t.integer "page_id"
-    t.integer "category_id"
+    t.integer "page_id",     limit: 4
+    t.integer "category_id", limit: 4
   end
 
   add_index "pages_categories", ["category_id"], name: "index_pages_categories_on_category_id", using: :btree
   add_index "pages_categories", ["page_id"], name: "index_pages_categories_on_page_id", using: :btree
 
   create_table "password_reset_tokens", force: :cascade do |t|
-    t.integer  "user_id"
-    t.string   "token"
+    t.integer  "user_id",    limit: 4
+    t.string   "token",      limit: 255
     t.datetime "expires_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "roles", force: :cascade do |t|
-    t.integer  "user_id"
-    t.string   "name"
+    t.integer  "user_id",    limit: 4
+    t.string   "name",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -187,8 +183,8 @@ ActiveRecord::Schema.define(version: 20151021103400) do
   add_index "roles", ["user_id"], name: "index_roles_on_user_id", using: :btree
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_id"
-    t.text     "data"
+    t.string   "session_id", limit: 255
+    t.text     "data",       limit: 65535
     t.datetime "updated_at"
   end
 
@@ -196,32 +192,32 @@ ActiveRecord::Schema.define(version: 20151021103400) do
   add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   create_table "taggings", force: :cascade do |t|
-    t.integer "tag_id"
-    t.integer "taggable_id"
-    t.string  "taggable_type"
+    t.integer "tag_id",        limit: 4
+    t.integer "taggable_id",   limit: 4
+    t.string  "taggable_type", limit: 255
   end
 
   add_index "taggings", ["tag_id"], name: "index_taggings_on_tag_id", using: :btree
   add_index "taggings", ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id", using: :btree
 
   create_table "tags", force: :cascade do |t|
-    t.string  "name"
-    t.boolean "pinned", default: false, null: false
+    t.string  "name",   limit: 255
+    t.boolean "pinned",             default: false, null: false
   end
 
   add_index "tags", ["name"], name: "index_tags_on_name", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "username"
-    t.string   "hashed_password"
-    t.string   "name"
-    t.string   "email"
+    t.string   "username",        limit: 255
+    t.string   "hashed_password", limit: 255
+    t.string   "name",            limit: 255
+    t.string   "email",           limit: 255
     t.datetime "last_login_at"
-    t.integer  "created_by"
+    t.integer  "created_by",      limit: 4
     t.datetime "created_at"
-    t.text     "persistent_data"
-    t.boolean  "activated",       default: false, null: false
-    t.integer  "image_id"
+    t.text     "persistent_data", limit: 65535
+    t.boolean  "activated",                     default: false, null: false
+    t.integer  "image_id",        limit: 4
   end
 
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -272,4 +272,40 @@ describe Page do
       it { is_expected.to eq(true) }
     end
   end
+
+  describe "#subpages" do
+    let!(:page1) do
+      create(:page,
+             position: 2,
+             pinned: true,
+             parent: page,
+             published_at: 3.days.ago)
+    end
+
+    let!(:page2) do
+      create(:page,
+             position: 3,
+             parent: page,
+             published_at: 2.days.ago)
+    end
+
+    let!(:page3) do
+      create(:page,
+             position: 1,
+             parent: page,
+             published_at: 1.days.ago)
+    end
+
+    subject { page.subpages.map(&:id) }
+
+    context "when page is a regular page" do
+      let(:page) { create(:page) }
+      it { is_expected.to eq([page3.id, page1.id, page2.id]) }
+    end
+
+    context "when page is a news page" do
+      let(:page) { create(:page, news_page: true) }
+      it { is_expected.to eq([page1.id, page3.id, page2.id]) }
+    end
+  end
 end


### PR DESCRIPTION
No need for unnecessary complexity, pages should be sorted by `published_at` if the parent is a news page, and manually if not.